### PR TITLE
Expand extension abstractions

### DIFF
--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -35,6 +35,7 @@
     "@solid-primitives/refs": "^0.3.0"
   },
   "peerDependencies": {
+    "@codemirror/lint": "^6.0.0",
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
     "solid-js": "^1.4.2"

--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -9,22 +9,24 @@ import {
   createTheme, 
   createWrapLine, 
   createLinter,
+  createLanguage,
   ExtensionsProps,
   LineNumbersProps, 
   ReadOnlyProps, 
   ThemeProps, 
-  LinterProps,
+  LinterProps, 
+  LanguageProps, 
   WrapLineProps, 
 } from "./utils";
 
-export type Props = CodeMirrorProps & LineNumbersProps & ReadOnlyProps & WrapLineProps & ExtensionsProps & ThemeProps  & LinterProps & JSX.HTMLAttributes<HTMLDivElement>;
+export type Props = CodeMirrorProps & LineNumbersProps & ReadOnlyProps & WrapLineProps & ExtensionsProps & ThemeProps & LanguageProps  & LinterProps & JSX.HTMLAttributes<HTMLDivElement>;
 
 export function CodeMirror(
   props: Props
 ) {
   let ref: HTMLDivElement | undefined;
 
-  const [codemirrorProps, lineNumberProps, readOnlyProps, wrapLineProps, extensionProps, themeProps, linterProps, others] = splitProps(props, ["value", "onValueChange", "onEditorMount"], ["showLineNumbers"], ["readOnly"], ["wrapLine"], ["extensions"], ["theme"], ["linter"]);
+  const [codemirrorProps, lineNumberProps, readOnlyProps, wrapLineProps, extensionProps, themeProps, linterProps, languageProps, others] = splitProps(props, ["value", "onValueChange", "onEditorMount"], ["showLineNumbers"], ["readOnly"], ["wrapLine"], ["extensions"], ["theme"], ["linter"], ["language"]);
   
   const { createExtension } = createCodeMirror(codemirrorProps, () => ref);
 
@@ -33,7 +35,8 @@ export function CodeMirror(
   createWrapLine(wrapLineProps, createExtension); 
   createTheme(themeProps, createExtension); 
   createExtensions(extensionProps, createExtension); 
-  createLinter(linterProps, createExtension);
+  createLinter(linterProps, createExtension); 
+  createLanguage(languageProps, createExtension); 
 
   return <div ref={mergeRefs(el => (ref = el), props.ref)} {...others} />;
 }

--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -2,16 +2,29 @@ import { onMount, splitProps } from "solid-js";
 import type { JSX } from "solid-js/jsx-runtime";
 import { mergeRefs } from "@solid-primitives/refs";
 import { type CodeMirrorProps, createCodeMirror  } from "@solid-codemirror/core";
-import { createExtensions, createLineNumbers, createReadOnly, createTheme, createWrapLine, ExtensionsProps, LineNumbersProps, ReadOnlyProps, ThemeProps, WrapLineProps } from "./utils";
+import { 
+  createExtensions, 
+  createLineNumbers, 
+  createReadOnly, 
+  createTheme, 
+  createWrapLine, 
+  createLinter,
+  ExtensionsProps,
+  LineNumbersProps, 
+  ReadOnlyProps, 
+  ThemeProps, 
+  LinterProps,
+  WrapLineProps, 
+} from "./utils";
 
-export type Props = CodeMirrorProps & LineNumbersProps & ReadOnlyProps & WrapLineProps & ExtensionsProps & ThemeProps & JSX.HTMLAttributes<HTMLDivElement>;
+export type Props = CodeMirrorProps & LineNumbersProps & ReadOnlyProps & WrapLineProps & ExtensionsProps & ThemeProps  & LinterProps & JSX.HTMLAttributes<HTMLDivElement>;
 
 export function CodeMirror(
   props: Props
 ) {
   let ref: HTMLDivElement | undefined;
 
-  const [codemirrorProps, lineNumberProps, readOnlyProps, wrapLineProps, extensionProps, themeProps, others] = splitProps(props, ["value", "onValueChange", "onEditorMount"], ["showLineNumbers"], ["readOnly"], ["wrapLine"], ["extensions"], ["theme"]);
+  const [codemirrorProps, lineNumberProps, readOnlyProps, wrapLineProps, extensionProps, themeProps, linterProps, others] = splitProps(props, ["value", "onValueChange", "onEditorMount"], ["showLineNumbers"], ["readOnly"], ["wrapLine"], ["extensions"], ["theme"], ["linter"]);
   
   const { createExtension } = createCodeMirror(codemirrorProps, () => ref);
 
@@ -20,7 +33,8 @@ export function CodeMirror(
   createWrapLine(wrapLineProps, createExtension); 
   createTheme(themeProps, createExtension); 
   createExtensions(extensionProps, createExtension); 
-  
+  createLinter(linterProps, createExtension);
+
   return <div ref={mergeRefs(el => (ref = el), props.ref)} {...others} />;
 }
 

--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -8,25 +8,27 @@ import {
   createReadOnly, 
   createTheme, 
   createWrapLine, 
-  createLinter,
-  createLanguage,
+  createLinter, 
+  createLanguage, 
+  createKeymap,
   ExtensionsProps,
   LineNumbersProps, 
   ReadOnlyProps, 
   ThemeProps, 
   LinterProps, 
   LanguageProps, 
+  KeymapProps,
   WrapLineProps, 
 } from "./utils";
 
-export type Props = CodeMirrorProps & LineNumbersProps & ReadOnlyProps & WrapLineProps & ExtensionsProps & ThemeProps & LanguageProps  & LinterProps & JSX.HTMLAttributes<HTMLDivElement>;
+export type Props = CodeMirrorProps & LineNumbersProps & ReadOnlyProps & WrapLineProps & ExtensionsProps & ThemeProps & LanguageProps & KeymapProps & LinterProps & JSX.HTMLAttributes<HTMLDivElement>;
 
 export function CodeMirror(
   props: Props
 ) {
   let ref: HTMLDivElement | undefined;
 
-  const [codemirrorProps, lineNumberProps, readOnlyProps, wrapLineProps, extensionProps, themeProps, linterProps, languageProps, others] = splitProps(props, ["value", "onValueChange", "onEditorMount"], ["showLineNumbers"], ["readOnly"], ["wrapLine"], ["extensions"], ["theme"], ["linter"], ["language"]);
+  const [codemirrorProps, lineNumberProps, readOnlyProps, wrapLineProps, extensionProps, themeProps, linterProps, languageProps, keymapProps, others] = splitProps(props, ["value", "onValueChange", "onEditorMount"], ["showLineNumbers"], ["readOnly"], ["wrapLine"], ["extensions"], ["theme"], ["linter"], ["language"], ["keymap"]);
   
   const { createExtension } = createCodeMirror(codemirrorProps, () => ref);
 
@@ -37,6 +39,7 @@ export function CodeMirror(
   createExtensions(extensionProps, createExtension); 
   createLinter(linterProps, createExtension); 
   createLanguage(languageProps, createExtension); 
+  createKeymap(keymapProps, createExtension); 
 
   return <div ref={mergeRefs(el => (ref = el), props.ref)} {...others} />;
 }

--- a/packages/codemirror/src/utils/createKeymap.ts
+++ b/packages/codemirror/src/utils/createKeymap.ts
@@ -1,0 +1,45 @@
+import type { Extension } from "@codemirror/state";
+import { createEffect, createMemo, mergeProps, on } from "solid-js";
+import { KeyBinding, keymap } from "@codemirror/view";
+
+
+export interface KeymapProps {
+  /**
+   * The CodeMirror keymap extension to use
+   */
+  keymap?: Extension;
+}
+
+export function createKeymap(
+  props: KeymapProps,
+  createExtension: (extension: Extension) => (extension: Extension) => void
+) {
+  const merged = mergeProps({ keymap: [] }, props);
+
+
+  const isKeyBindingArray = (km : Extension | KeyBinding[]) : km is KeyBinding[] => {
+    const first = Array.isArray(km) ? km[0] : km;
+    // AFAIK KeyBinding[] always have a run-callback as part of their interface
+    return "run" in first
+  }
+
+  const getKeymap = (km: Extension | KeyBinding[]) => isKeyBindingArray(km) ? keymap.of(km) : km
+
+  const keymaps = createMemo(()=>
+    Array.isArray(merged.keymap) 
+    ? merged.keymap.map(km => getKeymap(km)) 
+    : getKeymap(merged.keymap)
+  )
+
+  const reconfigureKeymap = createExtension(keymaps());
+
+  createEffect(
+    on(
+      () => keymaps,
+      (keymap) => {
+        reconfigureKeymap(keymaps());
+      },
+      { defer: true }
+    )
+  );
+}

--- a/packages/codemirror/src/utils/createLanguage.ts
+++ b/packages/codemirror/src/utils/createLanguage.ts
@@ -1,0 +1,28 @@
+import type { Extension } from "@codemirror/state";
+import { createEffect, mergeProps, on } from "solid-js";
+
+export interface LanguageProps {
+  /**
+   * The CodeMirror language extension to use
+   */
+  language?: Extension;
+}
+
+export function createLanguage(
+  props: LanguageProps,
+  createExtension: (extension: Extension) => (extension: Extension) => void
+) {
+  const merged = mergeProps({ language: [] }, props);
+
+  const reconfigureLanguage = createExtension(merged.language);
+
+  createEffect(
+    on(
+      () => merged.language,
+      (language) => {
+        reconfigureLanguage(language);
+      },
+      { defer: true }
+    )
+  );
+}

--- a/packages/codemirror/src/utils/createLinter.ts
+++ b/packages/codemirror/src/utils/createLinter.ts
@@ -1,5 +1,6 @@
 import type { Extension } from "@codemirror/state";
-import { createEffect, mergeProps, on } from "solid-js";
+import { createEffect, createMemo, mergeProps, on } from "solid-js";
+import { linter } from "@codemirror/lint";
 
 export interface LinterProps {
   /**
@@ -14,11 +15,20 @@ export function createLinter(
 ) {
   const merged = mergeProps({ linter: [] }, props);
 
-  const reconfigureLinter = createExtension(merged.linter);
+  const getLinter = (l: Extension ) => typeof l === "function" ? linter(l) : l
+
+  const linters = createMemo(()=>
+    Array.isArray(merged.linter) 
+      ? merged.linter.map(l => getLinter(l)) 
+      : getLinter(merged.linter)
+  
+  )
+
+  const reconfigureLinter = createExtension(linters());
 
   createEffect(
     on(
-      () => merged.linter,
+      () => linters(),
       (linter) => {
         reconfigureLinter(linter);
       },

--- a/packages/codemirror/src/utils/createLinter.ts
+++ b/packages/codemirror/src/utils/createLinter.ts
@@ -1,0 +1,28 @@
+import type { Extension } from "@codemirror/state";
+import { createEffect, mergeProps, on } from "solid-js";
+
+export interface LinterProps {
+  /**
+   * The CodeMirror linter extension to use
+   */
+  linter?: Extension;
+}
+
+export function createLinter(
+  props: LinterProps,
+  createExtension: (extension: Extension) => (extension: Extension) => void
+) {
+  const merged = mergeProps({ linter: [] }, props);
+
+  const reconfigureLinter = createExtension(merged.linter);
+
+  createEffect(
+    on(
+      () => merged.linter,
+      (linter) => {
+        reconfigureLinter(linter);
+      },
+      { defer: true }
+    )
+  );
+}

--- a/packages/codemirror/src/utils/index.ts
+++ b/packages/codemirror/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from "./createReadOnly";
 export * from "./createWrapLine";
 export * from "./createExtensions";
 export * from "./createTheme";
+export * from "./createLinter";

--- a/packages/codemirror/src/utils/index.ts
+++ b/packages/codemirror/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from "./createExtensions";
 export * from "./createTheme";
 export * from "./createLinter";
 export * from "./createLanguage";
+export * from "./createKeymap";

--- a/packages/codemirror/src/utils/index.ts
+++ b/packages/codemirror/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from "./createWrapLine";
 export * from "./createExtensions";
 export * from "./createTheme";
 export * from "./createLinter";
+export * from "./createLanguage";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ importers:
 
   packages/codemirror:
     specifiers:
+      '@codemirror/lint': ^6.0.0
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
       '@solid-codemirror/core': workspace:*
@@ -54,6 +55,7 @@ importers:
       vite-plugin-solid: ^2.2.6
       vitest: ^0.16.0
     dependencies:
+      '@codemirror/lint': 6.0.0
       '@solid-codemirror/core': link:../core
       '@solid-primitives/refs': 0.3.0_solid-js@1.4.7
     devDependencies:


### PR DESCRIPTION
I played around a bit with building some more abstractions around CodeMirror's Extensions-model following your example with createTheme and the theme-attribute in the component: I added attributes for linter, language and keymap.

Linter and language are just simple wrappers around createExtension, purely aesthetical. Keymap is a bit more elaborate, as it also allows for KeyBindings[] besides Extension: KeyBindings[] are checked for inside createKeymap and transformed into Extension by keymap.of(theKeyBinding).

with these abstractions I managed to transform

```
<CodeMirror
   extensions={[
      basicSetup,
      keymap.of(defaultKeymap),
      keymap.of(indentWithTab),
      xml(),
      lintGutter(),
      xmlLinter,
   ]}
   theme={oneDark}
/>
```

to 

```
<CodeMirror
   language={xml()}
   keymap={[basicSetup, defaultKeymap, indentWithTab]}
   linter={[xmlLinter, lintGutter()]}
   theme={oneDark}
/>
```

Drastically improving readability imo.

